### PR TITLE
feat: Enhance dataset wrappers and WebDataset for flexible data handling

### DIFF
--- a/config/mantis/imagenet/imagenet-resnet18.yaml
+++ b/config/mantis/imagenet/imagenet-resnet18.yaml
@@ -47,24 +47,46 @@ datasets:
       train:
         dataset_id: 'imagenet_label_chunked_for_tasks/train'
         params: 
-          original_dataset: 
-            type: 'ImageFolder' 
+          original_dataset:
+            type: 'WebDataset' # Changed from ImageFolder
             params:
-              root: '~/resources/datasets/ilsvrc2012/train' # <<< ADJUST PATH HERE
-              transform_params: # This list of dicts will be parsed by your transform utility
-                - type: 'RandomResizedCrop'
-                  params:
-                    size: [ 224, 224 ]
-                - type: 'RandomHorizontalFlip'
-                  params:
-                    p: 0.5
-                - type: 'ToTensor'
-                  params: {}
-                - type: 'Normalize'
-                  params:
-                    mean: [ 0.485, 0.456, 0.406 ]
-                    std: [ 0.229, 0.224, 0.225 ]
-          task_configs: 
+              url: 's3://YOUR_CEPH_BUCKET/path/to/imagenet-train-{000000..000146}.tar' # Please replace with your actual URL and shard pattern
+              # Optional: To make this WebDataset directly output tuples (e.g., image, label)
+              # instead of dictionaries. This can simplify wrapper configurations if the
+              # wrapper expects tuples directly.
+              # output_tuple_keys: ['jpg', 'cls']  # For specific keys if your .tar files have them, e.g. {'jpg': image_data, 'cls': label_data}
+              # OR, more specific for a common image/label pair:
+              # output_image_key: 'jpg'   # Key for the image data in the .tar sample
+              # output_label_key: 'cls'   # Key for the label data in the .tar sample
+              #
+              # If output_tuple_keys (or output_image_key/output_label_key) are used, 
+              # the WebDataset instance itself will yield tuples. In this case, wrappers 
+              # like LabelChunkedTaskDataset would not need their own image_key/label_key parameters
+              # as they would receive data already in tuple format.
+              # If these are commented out (as they are here), this WebDataset yields dictionaries.
+              transform: # Transform applied by WebDataset *before* yielding the sample (dict or tuple)
+                _target_: misc.datasets.registry.parse_transform_config_list
+                config:
+                  - type: 'RandomResizedCrop'
+                    params:
+                      size: [ 224, 224 ]
+                  - type: 'RandomHorizontalFlip'
+                    params:
+                      p: 0.5
+                  - type: 'ToTensor'
+                    params: {} # ToTensor usually doesn't need params from YAML
+                  - type: 'Normalize'
+                    params:
+                      mean: [ 0.485, 0.456, 0.406 ]
+                      std: [ 0.229, 0.224, 0.225 ]
+          # image_key and label_key for LabelChunkedTaskDataset:
+          # If the original_dataset (WebDataset above) is configured to output dictionaries
+          # (i.e., output_tuple_keys, output_image_key, output_label_key are NOT set in WebDataset's params),
+          # then these keys tell LabelChunkedTaskDataset how to extract image and label from the dictionary.
+          image_key: 'jpg' # Assumes WebDataset's imagehandler("torchrgb") outputs image under 'jpg', 'png', etc.
+          label_key: 'cls' # Assumes label is under 'cls' key in the WebDataset sample dictionary.
+                           # Adjust these if your .tar files use different keys (e.g., 'jpeg', 'label.txt').
+          task_configs:
             - task_id: 0
               original_labels: { range: [0, 500] } # Represents range(0, 500) -> labels 0...499
             - task_id: 1
@@ -75,29 +97,87 @@ datasets:
         dataset_id: 'imagenet_label_chunked_for_tasks/val'
         params: 
           original_dataset:
-            type: 'ImageFolder'
+            type: 'WebDataset' # Changed from ImageFolder
             params:
-              root: '~/resources/datasets/ilsvrc2012/val' # <<< ADJUST PATH HERE
-              transform_params:
-                - type: 'Resize'
-                  params:
-                    size: 256
-                - type: 'CenterCrop'
-                  params:
-                    size: [ 224, 224 ]
-                - type: 'ToTensor'
-                  params: {}
-                - type: 'Normalize'
-                  params:
-                    mean: [ 0.485, 0.456, 0.406 ]
-                    std: [ 0.229, 0.224, 0.225 ]
-          task_configs: 
+              url: 's3://YOUR_CEPH_BUCKET/path/to/imagenet-val-{000000..000007}.tar' # Please replace with your actual URL and shard pattern
+              # Optional: output_tuple_keys: ['jpg', 'cls'] or output_image_key/output_label_key
+              transform: # Changed from transform_params to the new structure
+                _target_: misc.datasets.registry.parse_transform_config_list
+                config:
+                  - type: 'Resize'
+                    params:
+                      size: 256
+                  - type: 'CenterCrop'
+                    params:
+                      size: [ 224, 224 ]
+                  - type: 'ToTensor'
+                    params: {} # ToTensor usually doesn't need params from YAML
+                  - type: 'Normalize'
+                    params:
+                      mean: [ 0.485, 0.456, 0.406 ]
+                      std: [ 0.229, 0.224, 0.225 ]
+          image_key: 'jpg' # For the val set wrapper
+          label_key: 'cls' # For the val set wrapper
+          task_configs:
             - task_id: 0
               original_labels: { range: [0, 500] }
             - task_id: 1
               original_labels: { range: [500, 1000] }
           default_task_id: -1
           default_task_label: -1
+
+  # 3. Example: LabelChunkedTaskDataset wrapping a WebDataset that yields dictionaries
+  # This dataset configuration is for demonstration and is not used by the main training pipeline above.
+  wrapped_webdataset_example:
+    name: 'wrapped_webdataset_example'
+    type: 'LabelChunkedTaskDataset' # The wrapper dataset
+    # No 'splits' here for this example, directly defining params for one instance
+    params:
+      # Configuration for the dataset to be wrapped
+      original_dataset: 
+        type: 'WebDataset'
+        params:
+          url: "s3://YOUR_CEPH_BUCKET/path/to/another-imagenet-train-{000000..000146}.tar" # Replace with actual URL
+          # This WebDataset is assumed to yield dictionaries (no output_tuple_keys used here).
+          # Its internal transform (e.g., basic decoding and ToTensor) should have already run if needed.
+          transform:
+            _target_: misc.datasets.registry.parse_transform_config_list
+            config:
+              # Minimal transforms if WebDataset handles decoding and basic type conversion.
+              # Example: if imagehandler("torchrgb") already gives tensors, ToTensor might not be needed here
+              # or could be part of the wrapper's transform instead.
+              # For this example, let's assume webdataset.decode.imagehandler("torchrgb") gives PIL, so ToTensor is needed.
+              - type: 'ToTensor' 
+      
+      # image_key and label_key for LabelChunkedTaskDataset:
+      # These tell the wrapper (LabelChunkedTaskDataset) how to extract the image and label
+      # from the dictionary samples provided by the 'original_dataset' (WebDataset above).
+      image_key: 'jpg'  # Assumes the image is under the 'jpg' key in the dictionary from WebDataset.
+                        # Common keys from webdataset.imagehandler are 'png', 'jpg', 'jpeg', 'ppm'.
+      label_key: 'cls'  # Assumes the label is under the 'cls' key. WebDataset files might use '.cls', '.txt', '.json' etc.
+      
+      # Task configuration for LabelChunkedTaskDataset
+      task_configs: 
+        - task_id: 0
+          original_labels: { range: [0, 100] } # Example: first 100 classes for task 0
+        - task_id: 1
+          original_labels: { range: [100, 200] } # Next 100 classes for task 1
+      default_task_id: -1      
+      default_task_label: -1
+
+      # Transform applied by LabelChunkedTaskDataset *after* extracting image and label
+      # using image_key and label_key. This transform receives the image.
+      transform: # This is the wrapper's transform
+        _target_: misc.datasets.registry.parse_transform_config_list
+        config:
+          - type: 'RandomResizedCrop'
+            params:
+              size: [224, 224]
+          - type: 'RandomHorizontalFlip'
+          - type: 'Normalize' # Normalize is typically applied after ToTensor and other augmentations
+            params:
+              mean: [0.485, 0.456, 0.406]
+              std: [0.229, 0.224, 0.225]
 
 models:
   lmbda: 0.025 

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ ttach==0.0.3
 typing_extensions==4.5.0
 urllib3==1.26.14
 zipp==3.15.0
+webdataset==0.2.47


### PR DESCRIPTION
This commit introduces several improvements to dataset handling:

1.  **Flexible Wrapper Datasets**:
    - `LabelChunkedTaskDataset` and `MultiSourceTaskDataset` in `misc/datasets/datasets.py` now accept optional `image_key` and `label_key` parameters in their constructors.
    - This allows them to correctly parse samples from underlying datasets that yield dictionaries (e.g., WebDataset) instead of just tuples. They fall back to tuple unpacking if these keys are not provided.

2.  **Configurable WebDataset Output**:
    - The WebDataset handler in `misc/datasets/registry.py` can now be configured using `output_tuple_keys` (a list of keys) or `output_image_key` and `output_label_key` in its YAML parameters.
    - If these parameters are provided, the WebDataset pipeline will use `webdataset.to_tuple()` to convert its dictionary samples into tuples before being returned by `get_dataset`. This makes WebDataset's output format more predictable and can simplify wrapper configurations.

3.  **Updated Configurations and Documentation**:
    - The example configuration in `config/mantis/imagenet/imagenet-resnet18.yaml` has been updated to demonstrate these new features, showing how `image_key`/`label_key` can be used in wrappers and how WebDataset can be configured to output tuples.
    - `README.md` has been updated to document these new capabilities for both wrapper datasets and WebDataset.

These changes improve the modularity and flexibility of the dataset pipeline, making it easier to integrate various dataset formats and sources, particularly for complex setups involving wrappers and services like WebDataset.